### PR TITLE
MMC3: Fix for 4-screen mirroring + CHR-RAM

### DIFF
--- a/rtl/mappers/MMC3.sv
+++ b/rtl/mappers/MMC3.sv
@@ -764,21 +764,20 @@ wire chr_ram_cs =
 		mapper192             ? chrsel[7:2]==6'b000010  :
 		mapper194             ? chrsel[7:1]==7'b0000000 :
 		mapper195             ? chrsel[7:2]==6'b000000  :
-		four_screen_mirroring ? chr_ain[13]             :
 		flags[15];
 
-assign chr_allow = chr_ram_cs;
+assign chr_allow = chr_ram_cs | (four_screen_mirroring & chr_ain[13]);
 assign chr_aout =
+		(four_screen_mirroring & chr_ain[13])? {10'b11_1111_1100,              chr_ain[11:0]} :   // DxROM/TVROM 4kb NT RAM
 		(TQROM & chr_ram_cs)                 ? {9'b11_1111_111,    chrsel[2:0], chr_ain[9:0]} :   // TQROM 8kb CHR-RAM
 		(mapper74 & chr_ram_cs)              ? {11'b11_1111_1111_1,chrsel[0],   chr_ain[9:0]} :   // 2kb CHR-RAM
 		(mapper191 & chr_ram_cs)             ? {11'b11_1111_1111_1,chrsel[0],   chr_ain[9:0]} :   // 2kb CHR-RAM
 		(mapper192 & chr_ram_cs)             ? {10'b11_1111_1111,  chrsel[1:0], chr_ain[9:0]} :   // 4kb CHR-RAM
 		(mapper194 & chr_ram_cs)             ? {11'b11_1111_1111_1,chrsel[0],   chr_ain[9:0]} :   // 2kb CHR-RAM
 		(mapper195 & chr_ram_cs)             ? {10'b11_1111_1111,  chrsel[1:0], chr_ain[9:0]} :   // 4kb CHR-RAM
-		(four_screen_mirroring & chr_ram_cs) ? {9'b11_1111_111,   chr_ain[13], chr_ain[11:0]} :   // DxROM 8kb CHR-RAM
 		(m268_chr_ram)                       ? {11'b11_1111_1111_1,            chr_ain[10:0]} :   // 2kb CHR-RAM
 		(mapper268)                          ? {4'b10_00,              map268c, chr_ain[9:0]} :   // Mapper 268 override
-		                                       {3'b10_0,                chrsel, chr_ain[9:0]};    // Standard MMC3
+		                                       {3'b10_0,                chrsel, chr_ain[9:0]};    // Standard MMC3 CHR-ROM/RAM
 
 wire ram_a13 = mapper268 && m268_reg[3][5] && (prg_ain[15:12] == 4'h5);
 assign prg_is_ram = (ram_a13 || (prg_ain[15:13] == 3'b011) && ((prg_ain[12:8] == 5'b1_1111) | ~internal_128)) //(>= 'h6000 && < 'h8000) && (==7Fxx or external_ram)


### PR DESCRIPTION
This fixes 4-screen mirroring and CHR-RAM on the MMC3 mapper, bringing it on par with the upstream MiSTer FPGA core.