### PR TITLE
Allow oversize mmc3

### DIFF
--- a/rtl/mappers/MMC3.sv
+++ b/rtl/mappers/MMC3.sv
@@ -388,7 +388,7 @@ wire MMC6 = ((flags[7:0] == 4) && (flags[24:21] == 1)); // mapper 4, submapper 1
 wire acclaim = ((flags[7:0] == 4) && (flags[24:21] == 3)); // Acclaim mapper
 wire mapper268 = ({flags[20:17],flags[7:0]} == 268); // Coolboy/Mindkids; Note: if mapper 268-256=12 was in this driver, it would need to check upper mapper bits
 wire mapper268_5k = (flags[24:21] == 1);
-wire oversized = mapper268;
+wire oversized = mapper268 || (flags[10:9] == 3); // If prg size in header is >= 1MB (prg_size==6 or 7) must be some way to access it. Allow oversize mmc3
 wire gnrom;
 wire lockout;
 wire gnrom_lock;


### PR DESCRIPTION
From upstream MiSTer: "If the nes header specifies a size greater than the mapper allows, there must be someway to access the data. Even though the original mmc3 does not support >512KB of prg, the header is specifying a non-standard mmc3."

This allows some MMC3 games, like this FF3 translation, to work on the core:
https://www.romhacking.net/translations/1590/

And here it is, the 1MB FF3 translation working on the Pocket thanks to this PR from the upstream MiSTer NES core:
![photo_2025-01-31_23-30-12](https://github.com/user-attachments/assets/cd12b3c6-e033-46d3-9cec-60c9d9bb91d4)
