### PR TITLE
make controller swapping non-persistent

### DIFF
--- a/pkg/pocket/Cores/agg23.NES/interact.json
+++ b/pkg/pocket/Cores/agg23.NES/interact.json
@@ -153,7 +153,7 @@
         "type": "check",
         "enabled": true,
         "address": "0x30C",
-        "persist": true,
+        "persist": false,
         "writeonly": true,
         "defaultval": 0,
         "value": 1


### PR DESCRIPTION
When rebooting or loading new games (such as turning on the console), the 2nd player controller rarely has the same control as 1st player, and can be confusing to users as to why nothing is working.